### PR TITLE
include existing environment variables

### DIFF
--- a/etcdenv.go
+++ b/etcdenv.go
@@ -36,7 +36,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	envs := []string{}
+	envs := os.Environ()
 	for _, n := range res {
 		key := strings.Split(n.Key, "/")
 		k, v := strings.ToUpper(key[len(key)-1]), n.Value


### PR DESCRIPTION
Existing environment variables will be passed to the command. Any environment variable retrieved from etcd will overwrite the existing variable.
