### PR TITLE
Env var configuration

### DIFF
--- a/etcdenv.go
+++ b/etcdenv.go
@@ -13,7 +13,7 @@ import (
 var sep = flag.Bool("s", false, "separate arguments with spaces")
 var key = flag.String("key", "", "etcd key")
 var host = flag.String("host", "", "etcd host")
-var hosts = []string{}
+var hosts []string
 
 func main() {
 	if len(os.Args) > 1 && strings.HasPrefix(os.Args[1], "-s ") {


### PR DESCRIPTION
This is the implementation of what I was thinking with issue #4.

To flesh out my use case some more:

If we replace /usr/bin/env on our docker image with etcdenv then we can configure it with environment variables while launching our container like this `docker run -e “ETCDENV_HOST=172.17.42.1” -e “ETCDENV_KEY=appname” imagename`.  This takes advantage of the fact that etcd on coreos is always available at 172.17.42.1. Our existing application scripts will get the environment variables because they start with `#!/usr/bin/env ruby`. This would allow us to get our configuration from etcd without any changes to our application.
