### PR TITLE
Make -key flag optional

### DIFF
--- a/etcdenv.go
+++ b/etcdenv.go
@@ -28,12 +28,6 @@ func main() {
 	if *key == "" {
 		*key = os.Getenv("ETCDENV_KEY")
 	}
-	if *key == "" {
-		fmt.Fprintln(os.Stderr, "etcdenv [-key=key] [...]")
-		flag.PrintDefaults()
-		os.Exit(1)
-	}
-
 	if *host == "" {
 		*host = os.Getenv("ETCDENV_HOST")
 	}
@@ -49,9 +43,11 @@ func main() {
 
 	envs := os.Environ()
 	for _, n := range res.Node.Nodes {
-		key := strings.Split(n.Key, "/")
-		k, v := strings.ToUpper(key[len(key)-1]), n.Value
-		envs = append(envs, k+"="+v)
+		if !n.Dir {
+			key := strings.Split(n.Key, "/")
+			k, v := strings.ToUpper(key[len(key)-1]), n.Value
+			envs = append(envs, k+"="+v)
+		}
 	}
 
 	if flag.NArg() == 0 {


### PR DESCRIPTION
This PR will make the -key flag optional.

If an empty key is provided, the v2 go-etcd will return all the keys for the root directory "/".

Example:
```sh
 $ curl -X PUT http://127.0.0.1:4001/v2/keys/mykey -d value="value!"
 
 $ curl http://127.0.0.1:4001/v2/keys/mykey                                                                                                                                                                           
 {"action":"get","node":{"key":"/mykey","value":"value!","modifiedIndex":2,"createdIndex":2}}
 
 $ curl http://127.0.0.1:4001/v2/keys/                                                                                                                                                                                      
 {"action":"get","node":{"dir":true,"nodes":[{"key":"/mykey","value":"value!","modifiedIndex":2,"createdIndex":2}],"modifiedIndex":1,"createdIndex":1}}
 
 $ etcdenv
 MYKEY=value!
```

