### PR TITLE
Add extra recursive flag

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -8,6 +8,7 @@ env command integrated with [etcd](http://coreos.com/docs/etcd/) server
 
     $ curl http://127.0.0.1:4001/v1/keys/app/db -d value="newdb"
     $ curl http://127.0.0.1:4001/v1/keys/app/cache -d value="new cache"
+    $ curl http://127.0.0.1:4001/v1/keys/app2/db -d value="otherdb"
 
     $ curl http://localhost:4001/v1/keys/app
     [{"action":"GET","key":"/app/db","value":"newdb","index":4},{"action":"GET","key":"/app/cache","value":"new cache","index":4}]
@@ -17,6 +18,10 @@ env command integrated with [etcd](http://coreos.com/docs/etcd/) server
     CACHE=new cache
 
     $ etcdenv -key=/app/ ruby web.rb
+
+    $ etcdenv -key=/ -r
+    DB=newdb,otherdb
+    CACHE=new cache
 
 ### Shebang
 
@@ -32,4 +37,3 @@ If you are using OSs which the shell doesn't parse arguments separated with spac
 
     $ cat Procfile
     web: etcdenv -key=/myapp/ ruby web.rb
-

--- a/etcdenv.go
+++ b/etcdenv.go
@@ -18,9 +18,9 @@ var host = flag.String("host", "", "etcd host")
 var hosts []string
 var envs []string
 
-func stringInSlice(s string, list []string) int {
+func prefixInSlice(list []string, s string) int {
 	for i, entry := range list {
-		if strings.Contains(entry, s) {
+		if strings.HasPrefix(entry, s) {
 			return i
 		}
 	}
@@ -31,8 +31,8 @@ func handleNode(n *etcd.Node) {
 	if !n.Dir {
 		key := strings.Split(n.Key, "/")
 		k, v := strings.ToUpper(key[len(key)-1]), n.Value
-		// if key already exists and in recursive mode, append with comma
-		if i := stringInSlice(k+"=", envs); i != -1 && *rec {
+		// if k already exists and in recursive mode, append v with comma
+		if i := prefixInSlice(envs, k+"="); i != -1 && *rec {
 			envs[i] = fmt.Sprint(envs[i], ",", v)
 		} else {
 			envs = append(envs, k+"="+v)

--- a/etcdenv.go
+++ b/etcdenv.go
@@ -3,17 +3,46 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/coreos/go-etcd/etcd"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
+
+	"github.com/coreos/go-etcd/etcd"
 )
 
 var sep = flag.Bool("s", false, "separate arguments with spaces")
+var rec = flag.Bool("r", false, "recursively fetch child values")
 var key = flag.String("key", "", "etcd key")
 var host = flag.String("host", "", "etcd host")
 var hosts []string
+var envs []string
+
+func stringInSlice(s string, list []string) int {
+	for i, entry := range list {
+		if strings.Contains(entry, s) {
+			return i
+		}
+	}
+	return -1
+}
+
+func handleNode(n *etcd.Node) {
+	if !n.Dir {
+		key := strings.Split(n.Key, "/")
+		k, v := strings.ToUpper(key[len(key)-1]), n.Value
+		// if key already exists and in recursive mode, append with comma
+		if i := stringInSlice(k+"=", envs); i != -1 && *rec {
+			envs[i] = fmt.Sprint(envs[i], ",", v)
+		} else {
+			envs = append(envs, k+"="+v)
+		}
+	} else if *rec {
+		for _, n2 := range n.Nodes {
+			handleNode(n2)
+		}
+	}
+}
 
 func main() {
 	if len(os.Args) > 1 && strings.HasPrefix(os.Args[1], "-s ") {
@@ -32,7 +61,7 @@ func main() {
 		*host = os.Getenv("ETCDENV_HOST")
 	}
 	if *host != "" {
-		hosts = []string{*host}
+		hosts = strings.Split(*host, ",")
 	}
 	client := etcd.NewClient(hosts)
 	res, err := client.Get(*key, true, true)
@@ -41,13 +70,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	envs := os.Environ()
+	envs = os.Environ()
 	for _, n := range res.Node.Nodes {
-		if !n.Dir {
-			key := strings.Split(n.Key, "/")
-			k, v := strings.ToUpper(key[len(key)-1]), n.Value
-			envs = append(envs, k+"="+v)
-		}
+		handleNode(n)
 	}
 
 	if flag.NArg() == 0 {


### PR DESCRIPTION
This adds an extra flag to go into fully recursive mode.
It also joins the values of repeating keys together.

eg:
$ etcdctl set /appx/hosta/port_http hosta:80
$ etcdctl set /appx/hosta/port_https hosta:443
$ etcdctl set /appx/hostb/port_http hostb:80
$ etcdenv -r -key /appx
PORT_HTTP=hosta:80,hostb:80
PORT_HTTPS=hosta:443

Could be used with https://github.com/spotify/docker-cassandra to
provide $CASSANDRA_SEEDS or similar
